### PR TITLE
Simplify lookup with O(1) set membership check

### DIFF
--- a/collections/ansible_collections/theforeman/foreman/tests/conftest.py
+++ b/collections/ansible_collections/theforeman/foreman/tests/conftest.py
@@ -14,7 +14,8 @@ def find_all_test_playbooks():
 
 ALL_TEST_PLAYBOOKS = list(find_all_test_playbooks())
 TEST_PLAYBOOKS = sorted([playbook for playbook in ALL_TEST_PLAYBOOKS if not playbook.startswith('inventory_plugin')])
-INVENTORY_PLAYBOOKS = sorted(set(ALL_TEST_PLAYBOOKS) - set(TEST_PLAYBOOKS))
+TEST_PLAYBOOKS_SET = set(TEST_PLAYBOOKS)
+INVENTORY_PLAYBOOKS = sorted(set(ALL_TEST_PLAYBOOKS) - TEST_PLAYBOOKS_SET)
 
 
 def pytest_addoption(parser):

--- a/collections/ansible_collections/theforeman/foreman/tests/test_crud.py
+++ b/collections/ansible_collections/theforeman/foreman/tests/test_crud.py
@@ -96,7 +96,7 @@ def test_crud(tmpdir, module, vcrmode):
 
 @pytest.mark.parametrize('module', TEST_PLAYBOOKS)
 def test_check_mode(tmpdir, module):
-    if module in ['subscription_manifest', 'templates_import', 'puppetclasses_import']:
+    if module in {'subscription_manifest', 'templates_import', 'puppetclasses_import'}:
         pytest.skip("This module does not support check_mode.")
     run = run_playbook_vcr(tmpdir, module, check_mode=True)
     assert run.rc == 0

--- a/collections/ansible_collections/theforeman/foreman/tests/test_module_state.py
+++ b/collections/ansible_collections/theforeman/foreman/tests/test_module_state.py
@@ -1,7 +1,7 @@
 import py.path
 import pytest
 
-from .conftest import TEST_PLAYBOOKS
+from .conftest import TEST_PLAYBOOKS_SET
 
 MODULES_PATH = py.path.local(__file__).realpath() / '..' / '..' / 'plugins' / 'modules'
 
@@ -22,7 +22,7 @@ def _module_file_path(module):
 
 
 def _module_is_tested(module):
-    return module in TEST_PLAYBOOKS
+    return module in TEST_PLAYBOOKS_SET
 
 
 @pytest.mark.parametrize('module', ALL_MODULES)


### PR DESCRIPTION
In this PR, I replaced list-based lookup with a set to improve performance from O(n) to O(1) when checking if a module is tested and in the check for supported the module.